### PR TITLE
Fix a few cross-platform issues

### DIFF
--- a/code/Makefile.am
+++ b/code/Makefile.am
@@ -343,6 +343,7 @@ FS2_SOURCES =	\
 	graphics/grstub.cpp	\
 	graphics/grstub.h	\
 	graphics/line.h	\
+	graphics/shadows.cpp \
 	graphics/tmapper.h	\
 	hud/hud.cpp	\
 	hud/hud.h	\
@@ -501,6 +502,7 @@ FS2_SOURCES =	\
 	model/modelsinc.h	\
 	model/modeloctant.cpp	\
 	model/modelread.cpp	\
+	model/modelrender.cpp   \
 	nebula/neb.cpp	\
 	nebula/neb.h	\
 	nebula/neblightning.cpp	\

--- a/code/graphics/gropengldraw.cpp
+++ b/code/graphics/gropengldraw.cpp
@@ -7,7 +7,7 @@
  *
 */
 
-
+#include <algorithm>
 #include "globalincs/pstypes.h"
 #include "cmdline/cmdline.h"
 #include "osapi/osapi.h"

--- a/code/io/timer.cpp
+++ b/code/io/timer.cpp
@@ -11,6 +11,8 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#else
+#include <SDL_timer.h>
 #endif
 
 #include <limits.h>
@@ -72,10 +74,10 @@ void timer_init()
 		Timer_perf_counter_freq = perf_frequency.QuadPart;
 #else
 		// get the performance counter start time
-		Timer_perf_counter_base = SDL_GetPerformanceCounter();
+		Timer_perf_counter_base = SDL_GetTicks();
 
 		// get the performance counter's ticks per second frequency
-		Timer_perf_counter_freq = SDL_GetPerformanceFrequency();
+		Timer_perf_counter_freq = 1000;
 #endif
 
 		Timer_inited = 1;
@@ -122,7 +124,7 @@ static longlong timer_get_perf_count()
 
 	return elapsed;
 #else
-	return SDL_GetPerformanceCounter() - Timer_perf_counter_base;
+	return SDL_GetTicks() - Timer_perf_counter_base;
 #endif
 }
 

--- a/code/model/modelinterp.cpp
+++ b/code/model/modelinterp.cpp
@@ -4790,30 +4790,6 @@ void interp_create_transparency_index_buffer(polymodel *pm, int mn)
 	}
 }
 
-inline int in_box(vec3d *min, vec3d *max, vec3d *pos, vec3d *view_pos)
-{
-	vec3d point;
-
-	vm_vec_sub(&point, view_pos, pos);
-
-	if ( (point.xyz.x >= min->xyz.x) && (point.xyz.x <= max->xyz.x)
-		&& (point.xyz.y >= min->xyz.y) && (point.xyz.y <= max->xyz.y)
-		&& (point.xyz.z >= min->xyz.z) && (point.xyz.z <= max->xyz.z) )
-	{
-		return 1;
-	}
-
-	return -1;
-}
-
-inline int in_sphere(vec3d *pos, float radius, vec3d *view_pos)
-{
-	if ( vm_vec_dist(view_pos, pos) <= radius )
-		return 1;
-	else
-		return -1;
-}
-
 void model_render_children_buffers_DEPRECATED(polymodel *pm, int mn, int detail_level, int render)
 {
 	int i;

--- a/code/model/modelrender.cpp
+++ b/code/model/modelrender.cpp
@@ -9,7 +9,7 @@
 
 #include "globalincs/pstypes.h"
 #include "io/timer.h"
-#include "Math/vecmat.h"
+#include "math/vecmat.h"
 #include "model/model.h"
 #include "model/modelrender.h"
 #include "ship/ship.h"
@@ -23,7 +23,7 @@
 #include "particle/particle.h"
 #include "gamesequence/gamesequence.h"
 #include "render/3dinternal.h"
-#include "Math/staticrand.h"
+#include "math/staticrand.h"
 
 extern int Model_texturing;
 extern int Model_polys;

--- a/code/model/modelrender.h
+++ b/code/model/modelrender.h
@@ -11,7 +11,7 @@
 #define _MODELRENDER_H
 
 #include "model/model.h"
-#include "Math/vecmat.h"
+#include "math/vecmat.h"
 #include "lighting/lighting.h"
 #include "graphics/gropengltnl.h"
 
@@ -25,8 +25,30 @@ extern vec3d Object_position;
 
 extern team_color* Current_team_color;
 
-extern inline int in_sphere(vec3d *pos, float radius, vec3d *view_pos);
-extern inline int in_box(vec3d *min, vec3d *max, vec3d *pos, vec3d *view_pos);
+inline int in_box(vec3d *min, vec3d *max, vec3d *pos, vec3d *view_pos)
+{
+	vec3d point;
+
+	vm_vec_sub(&point, view_pos, pos);
+
+	if ( (point.xyz.x >= min->xyz.x) && (point.xyz.x <= max->xyz.x)
+		&& (point.xyz.y >= min->xyz.y) && (point.xyz.y <= max->xyz.y)
+		&& (point.xyz.z >= min->xyz.z) && (point.xyz.z <= max->xyz.z) )
+	{
+		return 1;
+	}
+
+	return -1;
+}
+
+inline int in_sphere(vec3d *pos, float radius, vec3d *view_pos)
+{
+	if ( vm_vec_dist(view_pos, pos) <= radius )
+		return 1;
+	else
+		return -1;
+}
+
 extern int model_interp_get_texture(texture_info *tinfo, fix base_frametime);
 
 struct transform


### PR DESCRIPTION
These changes make it possible to compile your branch on Linux.

Why did you use ```SDL_GetPerformanceCounter```? That's part of SDL 2 and your branch still links against SDL 1.2.

I had to move the ```in_box``` and ```in_sphere``` functions into a header since gcc and clang apparently treat ```extern inline``` as ```extern```.