### PR TITLE
Fix a small issue on Linux

### DIFF
--- a/code/graphics/gropenglshader.cpp
+++ b/code/graphics/gropenglshader.cpp
@@ -377,6 +377,7 @@ static char *opengl_load_shader(shader_type type_id, char *filename, int flags)
 int opengl_compile_shader(shader_type sdr, uint flags)
 {
 	int sdr_index = -1;
+	int empty_idx;
 	char *vert = NULL, *frag = NULL, *geom = NULL;
 
 	bool in_error = false;
@@ -482,7 +483,7 @@ int opengl_compile_shader(shader_type sdr, uint flags)
 
 	// add it to our list of embedded shaders
 	// see if we have empty shader slots
-	int empty_idx = -1;
+	empty_idx = -1;
 	for ( int i = 0; i < (int)GL_shader.size(); ++i ) {
 		if ( GL_shader[i].shader == NUM_SHADER_TYPES ) {
 			empty_idx = i;


### PR DESCRIPTION
I'm not sure why MSVC allows this but both gcc and clang complain if you skip a declaration with a ```goto``` jump. I've moved the declaration to the beginning of the function but anywhere before the first ```goto``` is fine.

After this change, it compiles. I've played through the basic training mission and haven't encountered any issues so far.